### PR TITLE
Add --since and --until flags to mine local command

### DIFF
--- a/src/contextweaver/agents/mining_agent.py
+++ b/src/contextweaver/agents/mining_agent.py
@@ -142,10 +142,22 @@ class MiningAgent(BaseAgent):
         )
         return artifacts, status
 
-    def mine_local_git(self, repo_path: str, max_commits: int = 500) -> list[RawArtifact]:
+    def mine_local_git(
+        self,
+        repo_path: str,
+        max_commits: int = 500,
+        since: str | None = None,
+        until: str | None = None,
+    ) -> list[RawArtifact]:
         """
         Extract commit messages from a local git repository.
         Works without a GitHub token - great for private/air-gapped repos.
+
+        Args:
+            repo_path: Path to the git repository
+            max_commits: Maximum number of commits to process
+            since: Start date (YYYY-MM-DD or ISO format)
+            until: End date (YYYY-MM-DD or ISO format)
         """
         try:
             import git  # type: ignore
@@ -155,8 +167,30 @@ class MiningAgent(BaseAgent):
             self.log.error("mining.git_error", path=repo_path, error=str(exc))
             return []
 
+        # Parse date filters if provided
+        since_dt = None
+        until_dt = None
+        if since:
+            try:
+                since_dt = datetime.fromisoformat(since).replace(tzinfo=timezone.utc)
+            except ValueError:
+                self.log.warning("mining.invalid_since_date", since=since)
+        if until:
+            try:
+                until_dt = datetime.fromisoformat(until).replace(tzinfo=timezone.utc)
+            except ValueError:
+                self.log.warning("mining.invalid_until_date", until=until)
+
         artifacts = []
         for commit in list(repo.iter_commits())[:max_commits]:
+            commit_dt = datetime.fromtimestamp(commit.committed_date, tz=timezone.utc)
+
+            # Filter by date range if specified
+            if since_dt and commit_dt < since_dt:
+                continue
+            if until_dt and commit_dt > until_dt:
+                continue
+
             artifacts.append(
                 RawArtifact(
                     kind=ArtifactKind.COMMIT,
@@ -165,9 +199,7 @@ class MiningAgent(BaseAgent):
                     title=commit.summary,
                     body=commit.message,
                     author=commit.author.email,
-                    created_at=datetime.fromtimestamp(
-                        commit.committed_date, tz=timezone.utc
-                    ),
+                    created_at=commit_dt,
                     metadata={"files_changed": list(commit.stats.files.keys())[:20]},
                 )
             )

--- a/src/contextweaver/agents/orchestrator.py
+++ b/src/contextweaver/agents/orchestrator.py
@@ -107,12 +107,16 @@ class Orchestrator:
         self,
         repo_path: str,
         docs_dir: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
     ) -> list[Decision]:
         """
         Mine a local git repository (and optional docs dir) and index decisions.
         Works without any GitHub token.
         """
-        artifacts: list[RawArtifact] = self._miner.mine_local_git(repo_path)
+        artifacts: list[RawArtifact] = self._miner.mine_local_git(
+            repo_path, since=since, until=until
+        )
         if docs_dir:
             artifacts.extend(self._miner.mine_docs(docs_dir))
         artifacts.sort(key=lambda a: a.created_at)

--- a/src/contextweaver/cli/main.py
+++ b/src/contextweaver/cli/main.py
@@ -123,13 +123,15 @@ def mine_github(
 def mine_local(
     path: Annotated[str, typer.Argument(help="Path to local git repository")],
     docs: Annotated[Optional[str], typer.Option("--docs", help="Docs directory")] = None,
+    since: Annotated[Optional[str], typer.Option("--since", help="Start date (YYYY-MM-DD or ISO format)")] = None,
+    until: Annotated[Optional[str], typer.Option("--until", help="End date (YYYY-MM-DD or ISO format)")] = None,
 ) -> None:
     """Mine a local git repository for decisions."""
     console.print(Panel(f"[bold cyan]ContextWeaver[/] - Mining local repo: {path}"))
     orc = _get_orchestrator()
 
     with console.status("[bold green]Mining artifacts and running Decision Archaeology...[/]"):
-        decisions = orc.mine_local(path, docs_dir=docs)
+        decisions = orc.mine_local(path, docs_dir=docs, since=since, until=until)
 
     console.print(f"[green]Mining complete.[/] Extracted [bold]{len(decisions)}[/] decisions.")
     if decisions:


### PR DESCRIPTION
Adds date range filtering to the `contextweaver mine local` command, allowing users to mine only a specific date range of git history.

## Changes

- Added `--since` and `--until` CLI options to the `mine local` command
- Updated orchestrator to pass date filters through to the mining agent
- Implemented date filtering logic in `mine_local_git()` method
- Dates can be provided in ISO format or YYYY-MM-DD format

## Usage

```bash
# Mine commits from the last month
contextweaver mine local ./my-repo --since 2026-01-20

# Mine commits within a specific range
contextweaver mine local ./my-repo --since 2026-01-01 --until 2026-02-01
```

Closes #4